### PR TITLE
Support including schema source in generated code

### DIFF
--- a/argus/src/test/scala/argus/macros/FromSchemaSpec.scala
+++ b/argus/src/test/scala/argus/macros/FromSchemaSpec.scala
@@ -592,6 +592,28 @@ class FromSchemaSpec extends AnyFlatSpec with Matchers with JsonMatchers {
     Schema.Person(age=Some(42)).age should === (Some(42))
   }
 
+  it should "support raw schema inclusion" in {
+    val expected = """
+    {
+      "definitions" : {
+        "SSN" : { "type": "string" },
+        "Names" : { "type": "array", "items": { "type": "string" } }
+      }
+    }
+    """.filter(_ != '\n')
+
+    @fromSchemaJson("""
+    {
+      "definitions" : {
+        "SSN" : { "type": "string" },
+        "Names" : { "type": "array", "items": { "type": "string" } }
+      }
+    }
+    """, rawSchema = true)
+    object Foo
+
+    Foo.rawSchema should === (expected)
+  }
   "Complex example" should "work end to end" in {
     @fromSchemaResource("/vega-lite-schema.json")
     object Vega

--- a/argus/src/test/scala/argus/macros/FromSchemaSpec.scala
+++ b/argus/src/test/scala/argus/macros/FromSchemaSpec.scala
@@ -4,6 +4,7 @@ import java.io.File
 import java.time.ZonedDateTime
 import java.util.UUID
 
+import io.circe.argus.HasSchemaSource
 import io.circe.argus.json.JsonDiff
 import io.circe.argus.schema.Schema
 import cats.syntax.either._
@@ -612,8 +613,32 @@ class FromSchemaSpec extends AnyFlatSpec with Matchers with JsonMatchers {
     """, rawSchema = true)
     object Foo
 
-    Foo.rawSchema should === (expected)
+    Foo.schemaSource should === (expected)
   }
+
+  it should "generate HasSchemaSource instances" in {
+    val expected = """
+    {
+      "type": "object",
+      "properties": {
+        "name": { "type" : "string" }
+      }
+    }
+    """.filter(_ != '\n')
+
+    @fromSchemaJson("""
+    {
+      "type": "object",
+      "properties": {
+        "name": { "type" : "string" }
+      }
+    }
+    """, rawSchema = true, runtime = true)
+    object Foo
+
+    HasSchemaSource[Foo.Root].value should === (expected)
+  }
+
   "Complex example" should "work end to end" in {
     @fromSchemaResource("/vega-lite-schema.json")
     object Vega

--- a/build.sbt
+++ b/build.sbt
@@ -105,9 +105,14 @@ lazy val argus = project
       "org.scalatest" %% "scalatest" % Vers.scalatest % Test
     )
   )
+  .dependsOn(runtime % Test)
+
+lazy val runtime = project
+  .settings(moduleName := "circe-argus-runtime")
+  .settings(commonSettings: _*)
 
 lazy val root = (project in file("."))
-  .aggregate(argus)
+  .aggregate(argus, runtime)
   .settings(commonSettings: _*)
   .settings(noPublishSettings: _*)
 

--- a/runtime/src/main/scala/io/circe/argus/HasSchemaSource.scala
+++ b/runtime/src/main/scala/io/circe/argus/HasSchemaSource.scala
@@ -1,0 +1,16 @@
+package io.circe.argus
+
+/**
+ * Supports abstraction over Argus-generated types that have a schema string associated with them.
+ */ 
+trait HasSchemaSource[A] {
+  def value: String
+}
+
+object HasSchemaSource {
+  def apply[A](implicit instance: HasSchemaSource[A]): HasSchemaSource[A] = instance
+
+  def instance[A](source: String): HasSchemaSource[A] = new HasSchemaSource[A] {
+    def value: String = source
+  }
+}


### PR DESCRIPTION
This PR introduces two optional features:

1. It's now possible to include the schema source as a string in the generated companion object.
2. A new circe-argus-runtime dependency supports abstraction over Argus-generated (root) case classes that have schema sources associated with them.

Both features are currently very basic and the API around both is subject to change.