### PR TITLE
Support suppressing Union suffix for oneOf

### DIFF
--- a/argus/src/test/scala/argus/macros/FromSchemaSpec.scala
+++ b/argus/src/test/scala/argus/macros/FromSchemaSpec.scala
@@ -156,6 +156,42 @@ class FromSchemaSpec extends AnyFlatSpec with Matchers with JsonMatchers {
 
     val string = Root.AddressString("Main St")
     val street = Root.AddressStreet(Street("1010 Main St"))
+    val _ = string: Root.AddressUnion
+    val _ = street: Root.AddressUnion
+    Root(Some(street)).address.get match {
+      case Root.AddressStreet(st: Street) => st === (Street("1010 Main St"));
+      case _ => fail("Didn't match type")
+    }
+  }
+
+  it should "build union types without Union suffix when configured" in {
+    @fromSchemaJson("""
+    {
+      "type" : "object",
+      "definitions": {
+        "Street": {
+          "type": "object",
+          "properties" : { "street" : { "type" : "string" } },
+          "required" : ["street"]
+        }
+      },
+      "properties": {
+        "address": {
+          "oneOf": [
+            { "type": "string" },
+            { "$ref": "#/definitions/Street" }
+          ]
+        }
+      }
+    }
+    """, unionSuffix = false)
+    object Foo
+    import Foo._
+
+    val string = Root.AddressString("Main St")
+    val street = Root.AddressStreet(Street("1010 Main St"))
+    val _ = string: Root.Address
+    val _ = street: Root.Address
     Root(Some(street)).address.get match {
       case Root.AddressStreet(st: Street) => st === (Street("1010 Main St"));
       case _ => fail("Didn't match type")

--- a/argus/src/test/scala/argus/macros/FromSchemaSpec.scala
+++ b/argus/src/test/scala/argus/macros/FromSchemaSpec.scala
@@ -156,8 +156,8 @@ class FromSchemaSpec extends AnyFlatSpec with Matchers with JsonMatchers {
 
     val string = Root.AddressString("Main St")
     val street = Root.AddressStreet(Street("1010 Main St"))
-    val _ = string: Root.AddressUnion
-    val _ = street: Root.AddressUnion
+    val stringAsUnion = string: Root.AddressUnion
+    val streetAsUnion = street: Root.AddressUnion
     Root(Some(street)).address.get match {
       case Root.AddressStreet(st: Street) => st === (Street("1010 Main St"));
       case _ => fail("Didn't match type")
@@ -190,8 +190,8 @@ class FromSchemaSpec extends AnyFlatSpec with Matchers with JsonMatchers {
 
     val string = Root.AddressString("Main St")
     val street = Root.AddressStreet(Street("1010 Main St"))
-    val _ = string: Root.Address
-    val _ = street: Root.Address
+    val stringAsUnion = string: Root.Address
+    val streetAsUnion = street: Root.Address
     Root(Some(street)).address.get match {
       case Root.AddressStreet(st: Street) => st === (Street("1010 Main St"));
       case _ => fail("Didn't match type")


### PR DESCRIPTION
There's currently a bug where `oneOf` in `definitions` seems to result in the type being generated with a `Union` suffix in the definition, but not the use sites. In many cases the `Union` suffix is unnecessary, though, so I've just added an option here to suppress it.