### PR TITLE
Stop adding line breaks after commas in printed code

### DIFF
--- a/argus/src/main/scala/argus/macros/FromSchema.scala
+++ b/argus/src/main/scala/argus/macros/FromSchema.scala
@@ -136,7 +136,6 @@ class SchemaMacros(val c: Context) {
 
     // Clean up the code a little to make it more readable
     val code = packageCode + showCode(tree)
-      .replaceAll(",", ",\n")
       .replaceAll("\\.flatMap", "\n.flatMap")
 
     val file = new java.io.File(path)


### PR DESCRIPTION
These can cause problems with `schemaSource`, since it can result in string literals with line breaks.